### PR TITLE
[BUG] added position

### DIFF
--- a/items/D-758_082_001-01.jsonld.json
+++ b/items/D-758_082_001-01.jsonld.json
@@ -24,5 +24,8 @@
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0//"
   },
-  "schema:name": "Tasting notes-Chardonay, Undated - 01"
+  "schema:name": "Tasting notes-Chardonay, Undated - 01",
+  "schema:image": {
+    "@id": "@base:/media/dl/D-758_082_001-01_0001_recto.tif"
+  }
 }

--- a/items/D-758_082_001-01/media/dl/D-758_082_001-01_0001_recto.tif.jsonld.json
+++ b/items/D-758_082_001-01/media/dl/D-758_082_001-01_0001_recto.tif.jsonld.json
@@ -15,5 +15,6 @@
     "schema:MediaObject"
   ],
   "ebucore:filename": "D-758_082_001-01_0001_recto.tif",
-  "ebucore:hasMimeType": "image/tiff"
+  "ebucore:hasMimeType": "image/tiff",
+  "schema:position": "001"
 }

--- a/items/D-758_082_001-01/media/dl/D-758_082_001-01_0001_verso.tif.jsonld.json
+++ b/items/D-758_082_001-01/media/dl/D-758_082_001-01_0001_verso.tif.jsonld.json
@@ -15,5 +15,6 @@
     "schema:MediaObject"
   ],
   "ebucore:filename": "D-758_082_001-01_0001_verso.tif",
-  "ebucore:hasMimeType": "image/tiff"
+  "ebucore:hasMimeType": "image/tiff",
+  "schema:position": "002"
 }

--- a/items/D-758_082_001-01/media/dl/D-758_082_001-01_0002_recto.tif.jsonld.json
+++ b/items/D-758_082_001-01/media/dl/D-758_082_001-01_0002_recto.tif.jsonld.json
@@ -15,5 +15,6 @@
     "schema:MediaObject"
   ],
   "ebucore:filename": "D-758_082_001-01_0002_recto.tif",
-  "ebucore:hasMimeType": "image/tiff"
+  "ebucore:hasMimeType": "image/tiff",
+  "schema:position": "003"
 }

--- a/items/D-758_082_001-01/media/dl/D-758_082_001-01_0002_verso.tif.jsonld.json
+++ b/items/D-758_082_001-01/media/dl/D-758_082_001-01_0002_verso.tif.jsonld.json
@@ -15,5 +15,6 @@
     "schema:MediaObject"
   ],
   "ebucore:filename": "D-758_082_001-01_0002_verso.tif",
-  "ebucore:hasMimeType": "image/tiff"
+  "ebucore:hasMimeType": "image/tiff",
+  "schema:position": "004"
 }

--- a/items/D-758_082_001-01/media/dl/D-758_082_001-01_0003_recto.tif.jsonld.json
+++ b/items/D-758_082_001-01/media/dl/D-758_082_001-01_0003_recto.tif.jsonld.json
@@ -15,5 +15,6 @@
     "schema:MediaObject"
   ],
   "ebucore:filename": "D-758_082_001-01_0003_recto.tif",
-  "ebucore:hasMimeType": "image/tiff"
+  "ebucore:hasMimeType": "image/tiff",
+  "schema:position": "005"
 }

--- a/items/D-758_082_001-01/media/dl/D-758_082_001-01_0003_verso.tif.jsonld.json
+++ b/items/D-758_082_001-01/media/dl/D-758_082_001-01_0003_verso.tif.jsonld.json
@@ -15,5 +15,6 @@
     "schema:MediaObject"
   ],
   "ebucore:filename": "D-758_082_001-01_0003_verso.tif",
-  "ebucore:hasMimeType": "image/tiff"
+  "ebucore:hasMimeType": "image/tiff",
+  "schema:position": "006"
 }

--- a/items/D-758_082_001-01/media/dl/D-758_082_001-01_0004_recto.tif.jsonld.json
+++ b/items/D-758_082_001-01/media/dl/D-758_082_001-01_0004_recto.tif.jsonld.json
@@ -15,5 +15,6 @@
     "schema:MediaObject"
   ],
   "ebucore:filename": "D-758_082_001-01_0004_recto.tif",
-  "ebucore:hasMimeType": "image/tiff"
+  "ebucore:hasMimeType": "image/tiff",
+  "schema:position": "007"
 }

--- a/items/D-758_082_001-01/media/dl/D-758_082_001-01_0004_verso.tif.jsonld.json
+++ b/items/D-758_082_001-01/media/dl/D-758_082_001-01_0004_verso.tif.jsonld.json
@@ -15,5 +15,6 @@
     "schema:MediaObject"
   ],
   "ebucore:filename": "D-758_082_001-01_0004_verso.tif",
-  "ebucore:hasMimeType": "image/tiff"
+  "ebucore:hasMimeType": "image/tiff",
+  "schema:position": "008"
 }

--- a/items/D-758_082_001-01/media/dl/D-758_082_001-01_0005_recto.tif.jsonld.json
+++ b/items/D-758_082_001-01/media/dl/D-758_082_001-01_0005_recto.tif.jsonld.json
@@ -15,5 +15,6 @@
     "schema:MediaObject"
   ],
   "ebucore:filename": "D-758_082_001-01_0005_recto.tif",
-  "ebucore:hasMimeType": "image/tiff"
+  "ebucore:hasMimeType": "image/tiff",
+  "schema:position": "009"
 }

--- a/items/D-758_082_001-01/media/dl/D-758_082_001-01_0005_verso.tif.jsonld.json
+++ b/items/D-758_082_001-01/media/dl/D-758_082_001-01_0005_verso.tif.jsonld.json
@@ -15,5 +15,6 @@
     "schema:MediaObject"
   ],
   "ebucore:filename": "D-758_082_001-01_0005_verso.tif",
-  "ebucore:hasMimeType": "image/tiff"
+  "ebucore:hasMimeType": "image/tiff",
+  "schema:position": "010"
 }

--- a/items/D-758_082_001-01/media/dl/D-758_082_001-01_0006_recto.tif.jsonld.json
+++ b/items/D-758_082_001-01/media/dl/D-758_082_001-01_0006_recto.tif.jsonld.json
@@ -15,5 +15,6 @@
     "schema:MediaObject"
   ],
   "ebucore:filename": "D-758_082_001-01_0006_recto.tif",
-  "ebucore:hasMimeType": "image/tiff"
+  "ebucore:hasMimeType": "image/tiff",
+  "schema:position": "011"
 }

--- a/items/D-758_082_001-01/media/dl/D-758_082_001-01_0006_verso.tif.jsonld.json
+++ b/items/D-758_082_001-01/media/dl/D-758_082_001-01_0006_verso.tif.jsonld.json
@@ -15,5 +15,6 @@
     "schema:MediaObject"
   ],
   "ebucore:filename": "D-758_082_001-01_0006_verso.tif",
-  "ebucore:hasMimeType": "image/tiff"
+  "ebucore:hasMimeType": "image/tiff",
+  "schema:position": "012"
 }

--- a/items/D-758_082_001-01/media/dl/D-758_082_001-01_0007_recto.tif.jsonld.json
+++ b/items/D-758_082_001-01/media/dl/D-758_082_001-01_0007_recto.tif.jsonld.json
@@ -15,5 +15,6 @@
     "schema:MediaObject"
   ],
   "ebucore:filename": "D-758_082_001-01_0007_recto.tif",
-  "ebucore:hasMimeType": "image/tiff"
+  "ebucore:hasMimeType": "image/tiff",
+  "schema:position": "013"
 }

--- a/items/D-758_082_001-01/media/dl/D-758_082_001-01_0007_verso.tif.jsonld.json
+++ b/items/D-758_082_001-01/media/dl/D-758_082_001-01_0007_verso.tif.jsonld.json
@@ -15,5 +15,6 @@
     "schema:MediaObject"
   ],
   "ebucore:filename": "D-758_082_001-01_0007_verso.tif",
-  "ebucore:hasMimeType": "image/tiff"
+  "ebucore:hasMimeType": "image/tiff",
+  "schema:position": "014"
 }

--- a/items/D-758_082_001-01/media/dl/D-758_082_001-01_0008_recto.tif.jsonld.json
+++ b/items/D-758_082_001-01/media/dl/D-758_082_001-01_0008_recto.tif.jsonld.json
@@ -15,5 +15,6 @@
     "schema:MediaObject"
   ],
   "ebucore:filename": "D-758_082_001-01_0008_recto.tif",
-  "ebucore:hasMimeType": "image/tiff"
+  "ebucore:hasMimeType": "image/tiff",
+  "schema:position": "015"
 }

--- a/items/D-758_082_001-01/media/dl/D-758_082_001-01_0008_verso.tif.jsonld.json
+++ b/items/D-758_082_001-01/media/dl/D-758_082_001-01_0008_verso.tif.jsonld.json
@@ -15,5 +15,6 @@
     "schema:MediaObject"
   ],
   "ebucore:filename": "D-758_082_001-01_0008_verso.tif",
-  "ebucore:hasMimeType": "image/tiff"
+  "ebucore:hasMimeType": "image/tiff",
+  "schema:position": "016"
 }

--- a/items/D-758_082_001-01/media/dl/D-758_082_001-01_0009_recto.tif.jsonld.json
+++ b/items/D-758_082_001-01/media/dl/D-758_082_001-01_0009_recto.tif.jsonld.json
@@ -15,5 +15,6 @@
     "schema:MediaObject"
   ],
   "ebucore:filename": "D-758_082_001-01_0009_recto.tif",
-  "ebucore:hasMimeType": "image/tiff"
+  "ebucore:hasMimeType": "image/tiff",
+  "schema:position": "017"
 }

--- a/items/D-758_082_001-01/media/dl/D-758_082_001-01_0009_verso.tif.jsonld.json
+++ b/items/D-758_082_001-01/media/dl/D-758_082_001-01_0009_verso.tif.jsonld.json
@@ -15,5 +15,6 @@
     "schema:MediaObject"
   ],
   "ebucore:filename": "D-758_082_001-01_0009_verso.tif",
-  "ebucore:hasMimeType": "image/tiff"
+  "ebucore:hasMimeType": "image/tiff",
+  "schema:position": "018"
 }

--- a/items/D-758_082_001-01/media/dl/D-758_082_001-01_0010_recto.tif.jsonld.json
+++ b/items/D-758_082_001-01/media/dl/D-758_082_001-01_0010_recto.tif.jsonld.json
@@ -15,5 +15,6 @@
     "schema:MediaObject"
   ],
   "ebucore:filename": "D-758_082_001-01_0010_recto.tif",
-  "ebucore:hasMimeType": "image/tiff"
+  "ebucore:hasMimeType": "image/tiff",
+  "schema:position": "019"
 }

--- a/items/D-758_082_001-01/media/dl/D-758_082_001-01_0010_verso.tif.jsonld.json
+++ b/items/D-758_082_001-01/media/dl/D-758_082_001-01_0010_verso.tif.jsonld.json
@@ -15,5 +15,6 @@
     "schema:MediaObject"
   ],
   "ebucore:filename": "D-758_082_001-01_0010_verso.tif",
-  "ebucore:hasMimeType": "image/tiff"
+  "ebucore:hasMimeType": "image/tiff",
+  "schema:position": "020"
 }

--- a/items/D-758_082_001-01/media/dl/D-758_082_001-01_0011_recto.tif.jsonld.json
+++ b/items/D-758_082_001-01/media/dl/D-758_082_001-01_0011_recto.tif.jsonld.json
@@ -15,5 +15,6 @@
     "schema:MediaObject"
   ],
   "ebucore:filename": "D-758_082_001-01_0011_recto.tif",
-  "ebucore:hasMimeType": "image/tiff"
+  "ebucore:hasMimeType": "image/tiff",
+  "schema:position": "021"
 }

--- a/items/D-758_082_001-01/media/dl/D-758_082_001-01_0011_verso.tif.jsonld.json
+++ b/items/D-758_082_001-01/media/dl/D-758_082_001-01_0011_verso.tif.jsonld.json
@@ -15,5 +15,6 @@
     "schema:MediaObject"
   ],
   "ebucore:filename": "D-758_082_001-01_0011_verso.tif",
-  "ebucore:hasMimeType": "image/tiff"
+  "ebucore:hasMimeType": "image/tiff",
+  "schema:position": "022"
 }

--- a/items/D-758_082_001-01/media/dl/D-758_082_001-01_0012_recto.tif.jsonld.json
+++ b/items/D-758_082_001-01/media/dl/D-758_082_001-01_0012_recto.tif.jsonld.json
@@ -15,5 +15,6 @@
     "schema:MediaObject"
   ],
   "ebucore:filename": "D-758_082_001-01_0012_recto.tif",
-  "ebucore:hasMimeType": "image/tiff"
+  "ebucore:hasMimeType": "image/tiff",
+  "schema:position": "023"
 }

--- a/items/D-758_082_001-01/media/dl/D-758_082_001-01_0012_verso.tif.jsonld.json
+++ b/items/D-758_082_001-01/media/dl/D-758_082_001-01_0012_verso.tif.jsonld.json
@@ -15,5 +15,6 @@
     "schema:MediaObject"
   ],
   "ebucore:filename": "D-758_082_001-01_0012_verso.tif",
-  "ebucore:hasMimeType": "image/tiff"
+  "ebucore:hasMimeType": "image/tiff",
+  "schema:position": "024"
 }


### PR DESCRIPTION
The first item with a thumbnail is
`./items/D-758-082_001-01/thumbnail.jpg.jsonld.json`

    "schema:about": {
      "@id": "http://id.worldcat.org/fast/1175993"
    },
    "schema:associatedMedia": {
      "@id": "@base:/media/D-758_082_001-01.pdf"
    },
    "schema:description": "1993-1999 vintages",
    "schema:identifier": [
      "D-758, Box:82, Folder:1",
      "ark:/87293/d31n7xt97"
    ],
    "schema:image": {
      "@id": "@base:/thumbnail.jpg"
    },
    "schema:license": {
      "@id": "http://rightsstatements.org/vocab/InC-NC/1.0//"
    },
    "schema:name": "Tasting notes-Chardonay, Undated - 01"

The PDF reader is what comes up for that.  Let&rsquo;s just remove the thumbnail
completely, no image, and see what happens.

    git restore --source all-items --staged --worktree ./items/D-758_082_001-01 ./items/D-758_082_001-01.jsonld.json

Then, I removed the `associatedMedia` and the `image` from the item metadata,
they should be fine.  After committing, I need to add more binaries.  This
s

    gsutil -m rsync -c -J -r -y "^(\.git|\.gitignore|.*\.jsonld\.json)$" ./items/D-758_082_001-01/ gs://dams-collections-binary-backups/bv./items/D-758_082_001-01/

1.  schema:image

        let n=0; for i in *.json; do d=$(basename $i .jsonld.json); echo $i $d; x=$(ls $d/media/dl/*.tif.jsonld.json | head -1 | sed -e 's/.jsonld.json//' -e "s|^$d|@base:|"); cp $i $i-; jq --arg x ${x} '.+{"schema:image":{"@id":$x}}' $i- > $i; rm $i- ; done

2.  schema:position

        let n=0;
        for i in *.json; do
            cp $i ${i}-;
            let n=$n+1;
            f=$(printf %03i $n);
            jq --arg f ${f} '.+{"schema:position":$f}' ${i}- > $i;
            rm ${i}-;
        done
